### PR TITLE
Restored grids to figures

### DIFF
--- a/tfac/figures/figure2.py
+++ b/tfac/figures/figure2.py
@@ -8,11 +8,6 @@ from ..dataImport import form_tensor
 from ..predict import evaluate_components, evaluate_scaling
 from tensorpack import perform_CMTF, calcR2X
 
-LABEL_POS = (
-    (0.025, 0.52),
-    (0.94, 0.455)
-)
-
 
 def get_r2x_results():
     """

--- a/tfac/figures/figure2.py
+++ b/tfac/figures/figure2.py
@@ -85,7 +85,7 @@ def plot_results(r2x_v_components, r2x_v_scaling, acc_v_components,
     axs[0].set_ylim(0, 1)
     axs[0].set_xticks(r2x_v_components.index)
     axs[0].text(
-        -0.35,
+        -0.25,
         0.9,
         'A',
         fontsize=14,
@@ -105,7 +105,7 @@ def plot_results(r2x_v_components, r2x_v_scaling, acc_v_components,
     axs[1].set_ylim(0, 1)
     axs[1].tick_params(axis='x', pad=-3)
     axs[1].text(
-        -0.35,
+        -0.25,
         0.9,
         'B',
         fontsize=14,
@@ -121,7 +121,7 @@ def plot_results(r2x_v_components, r2x_v_scaling, acc_v_components,
     axs[2].set_xticks(acc_v_components.index)
     axs[2].set_ylim([0.5, 0.75])
     axs[2].text(
-        -0.35,
+        -0.25,
         0.9,
         'C',
         fontsize=14,
@@ -138,7 +138,7 @@ def plot_results(r2x_v_components, r2x_v_scaling, acc_v_components,
     axs[3].set_xticks(np.logspace(-7, 7, base=2, num=8))
     axs[3].tick_params(axis='x', pad=-3)
     axs[3].text(
-        -0.35,
+        -0.25,
         0.9,
         'D',
         fontsize=14,

--- a/tfac/figures/figureCommon.py
+++ b/tfac/figures/figureCommon.py
@@ -16,10 +16,12 @@ OPTIMAL_SCALING = 32.0
 
 
 matplotlib.rcParams["axes.labelsize"] = 10
+matplotlib.rcParams["axes.linewidth"] = 0.6
 matplotlib.rcParams["axes.titlesize"] = 12
 matplotlib.rcParams["font.family"] = ["sans-serif"]
 matplotlib.rcParams["font.sans-serif"] = ["Arial"]
 matplotlib.rcParams["font.size"] = 8
+matplotlib.rcParams["grid.linestyle"] = "dotted"
 matplotlib.rcParams["legend.borderpad"] = 0.35
 matplotlib.rcParams["legend.fontsize"] = 7
 matplotlib.rcParams["legend.framealpha"] = 0.5
@@ -38,11 +40,13 @@ matplotlib.rcParams["ytick.minor.pad"] = 0.9
 
 def getSetup(figsize, gridd, multz=None, empts=None, style="whitegrid"):
     """ Establish figure set-up with subplots. """
-    sns.set_style(
-        style,
-        rc=matplotlib.rcParams
+    sns.set(
+        style=style,
+        font_scale=0.7,
+        color_codes=True,
+        palette="colorblind",
+        rc=plt.rcParams
     )
-    sns.set_palette('colorblind')
 
     # create empty list if empts isn't specified
     if empts is None:


### PR DESCRIPTION
 - getSetup now adds grids to plots by default
 - Grids can be removed by specifying style in getSetup call